### PR TITLE
Replace HASHABLE with equivalent from Stdlib

### DIFF
--- a/lib/hamt.ml
+++ b/lib/hamt.ml
@@ -23,11 +23,6 @@ module StdConfig32 : CONFIG = struct
   let arrnode_min = 4
 end
 
-module type HASHABLE = sig
-  type t
-  val hash : t -> int
-end
-
 module type S = sig
   type key
   type 'a t
@@ -112,7 +107,7 @@ module type S = sig
   end
 end
 
-module Make (Config : CONFIG) (Key : HASHABLE) : S with type key = Key.t
+module Make (Config : CONFIG) (Key : Hashtbl.HashedType) : S with type key = Key.t
 =
 struct
 

--- a/lib/hamt.mli
+++ b/lib/hamt.mli
@@ -45,17 +45,6 @@ module StdConfig32 : CONFIG
     ]}
 *)
 
-module type HASHABLE = sig
-  (** Input signature for the hashable keys module. *)
-
-  type t
-  (** The type of hashable elements, to be used as keys. *)
-
-  val hash : t -> int
-  (** A hash function on [t] values. *)
-
-end
-
 module type S = sig
   (** Output signature of the {!Make} module. *)
 
@@ -321,7 +310,7 @@ module type S = sig
   end
 end
 
-module Make (Config : CONFIG) (Key : HASHABLE) : S with type key = Key.t
+module Make (Config : CONFIG) (Key : Hashtbl.HashedType) : S with type key = Key.t
 (** Functor building an implementation of the Hamt structure,
     given a hashable type. *)
 

--- a/lib_test/param.ml
+++ b/lib_test/param.ml
@@ -19,8 +19,7 @@ module Config =
     else (module Hamt.StdConfig)
     : Hamt.CONFIG)
 
-module AssocHamt = Hamt.Make (Config)
-    (struct type t = int let hash = Hashtbl.hash end)
+module AssocHamt = Hamt.Int
 
 module AssocMap = Map.Make
     (struct type t = int let compare = compare end)


### PR DESCRIPTION
Inspired by https://github.com/rgrinberg/ocaml-hamt/commit/ab4ae4d219f31930d3f2962ab3eb315de6b760df

The advantage is that given the `module type` is in the Stdlib, it makes interop easier with types that are hashable and probably implement that signature.