### PR TITLE
Implement API changes to align with published 1.0.0 package

### DIFF
--- a/lib/hamt.ml
+++ b/lib/hamt.ml
@@ -36,6 +36,7 @@ module type S = sig
   val is_empty : 'a t -> bool
   val singleton : key -> 'a -> 'a t
   val cardinal : 'a t -> int
+  val length : 'a t -> int
 
   val alter : key -> ('a option -> 'a option) -> 'a t -> 'a t
   val add : key -> 'a -> 'a t -> 'a t
@@ -46,7 +47,7 @@ module type S = sig
   val modify : key -> ('a -> 'a) -> 'a t -> 'a t
   val modify_def : 'a -> key -> ('a -> 'a) -> 'a t -> 'a t
 
-  val find : key -> 'a t -> 'a
+  val find_exn : key -> 'a t -> 'a
   val mem : key -> 'a t -> bool
   val choose : 'a t -> key * 'a
   val pop : 'a t -> (key * 'a) * 'a t
@@ -456,7 +457,7 @@ struct
     | BitmapIndexedNode (_, base) -> Array.iter (iter f) base
     | ArrayNode (_, children) -> Array.iter (iter f) children
 
-  let find key =
+  let find_exn key =
     let rec find shift hash key = function
       | Empty -> raise Not_found
       | Leaf (_, k, v) -> if k = key then v else raise Not_found
@@ -474,7 +475,7 @@ struct
 
   let mem key hamt =
     try
-      let _ = find key hamt in true
+      let _ = find_exn key hamt in true
     with
     | Not_found -> false
 
@@ -549,7 +550,7 @@ struct
       | Empty, _ -> Empty
       | Leaf (h, k, v), _ ->
         begin
-          try Leaf (h, k, f k v (find k t2))
+          try Leaf (h, k, f k v (find_exn k t2))
           with Not_found -> Empty
         end
       | HashCollision (h1, li1), HashCollision (h2, li2)->
@@ -691,12 +692,12 @@ struct
     let extract k hamt = try let v, r = extract k hamt in Some v, r with Not_found -> None, hamt
     let update k f hamt = try update k f hamt with Not_found -> hamt
     let modify k f hamt = try modify k f hamt with Not_found -> hamt
-    let find k hamt = try Some (find k hamt) with Not_found -> None
+    let find k hamt = try Some (find_exn k hamt) with Not_found -> None
     let choose hamt = try Some (choose hamt) with Not_found -> None
   end
 
   module Infix = struct
-    let ( --> ) hamt k = find k hamt
+    let ( --> ) hamt k = find_exn k hamt
     let ( <-- ) hamt (k, v) = add k v hamt
   end
 end

--- a/lib/hamt.ml
+++ b/lib/hamt.ml
@@ -149,6 +149,8 @@ struct
     | ArrayNode (_, children) ->
       Array.fold_left (fun acc child -> acc + cardinal child) 0 children
 
+  let length = cardinal
+
   let is_tip_node = function
     | Empty | Leaf (_, _, _) | HashCollision (_, _) -> true
     | _ -> false

--- a/lib/hamt.mli
+++ b/lib/hamt.mli
@@ -77,6 +77,9 @@ module type S = sig
   val cardinal : 'a t -> int
   (** Returns the number of bindings of a table. *)
 
+  val length : 'a t -> int
+  (** alias of [cardinal] *)
+
   (** {3 Modify bindings } *)
 
   val alter : key -> ('a option -> 'a option) -> 'a t -> 'a t

--- a/lib/hamt.mli
+++ b/lib/hamt.mli
@@ -124,8 +124,8 @@ module type S = sig
 
   (** {3 Getting elements } *)
 
-  val find : key -> 'a t -> 'a
-  (** [find k t] returns the value bound from the key [k] in [t]. If
+  val find_exn : key -> 'a t -> 'a
+  (** [find_exn k t] returns the value bound from the key [k] in [t]. If
       there is no such binding, [Not_found] is raised. *)
 
   val mem : key -> 'a t -> bool
@@ -315,7 +315,7 @@ module type S = sig
   sig
     val ( --> ) : 'a t -> key -> 'a
     (** [t --> k] returns the current binding of [k] in [t], or
-        raises [Not_found]. Strictly equivalent to [find k t]. *)
+        raises [Not_found]. Strictly equivalent to [find_exn k t]. *)
 
     val ( <-- ) : 'a t -> key * 'a -> 'a t
     (** [t <-- (k, v)] adds to [t] a binding from [k] to [v] and

--- a/lib_test/param.ml
+++ b/lib_test/param.ml
@@ -6,7 +6,7 @@ module type Assoc = sig
   type key = int
   type 'a t
   val empty : 'a t
-  val find : key -> 'a t -> 'a
+  val find_exn : key -> 'a t -> 'a
   val add : key -> 'a -> 'a t -> 'a t
 end
 
@@ -22,8 +22,10 @@ module Config =
 module AssocHamt = Hamt.Make (Config)
     (struct type t = int let hash = Hashtbl.hash end)
 
-module AssocMap = Map.Make
-    (struct type t = int let compare = compare end)
+module AssocMap = struct
+  include Map.Make (struct type t = int let compare = compare end)
+  let find_exn = find
+end
 
 let implem, nbiter, should_test_add, should_test_find =
   let format = "implem:(hamt|map) nbiter:[0-9]* options:(add|find)* [--arch64={true,false}]" in
@@ -69,7 +71,7 @@ let rec test_add t = function
 let rec test_find t = function
   | [] -> ()
   | i::input ->
-    begin try M.find i t with _ -> () end;
+    begin try M.find_exn i t with _ -> () end;
     test_find t input
 
 let () =


### PR DESCRIPTION
As @thizanne wanted to keep the API of the released OPAM package this commit is cherry-picking the changes by @rgrinberg to the public API.

Personally I do like marking things that throw `_exn` but not all of them do. So for a future (2.0.0?) release I would go ahead and rename all the throwing functions into `_exn` and move the `ExceptionLess` module to the top-level.

But for now this should implement exactly the same API as `hamt.1.0.0` on OPAM so it should be possible to release it as e.g. `hamt.1.0.1` without breaking changes.