### PR TITLE
fix: follow stdlib for union

### DIFF
--- a/lib/hamt.ml
+++ b/lib/hamt.ml
@@ -101,9 +101,7 @@ module type S = sig
   val merge :
     (key -> 'a option -> 'b option -> 'c option) -> 'a t -> 'b t -> 'c t
 
-  val union : 'a t -> 'a t -> 'a t
-
-  val union_f : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  val union : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
 
   module Import : sig
     module type FOLDABLE = sig
@@ -674,10 +672,7 @@ module Make (Config : CONFIG) (Key : Hashtbl.HashedType) :
 
   let merge f t1 t2 = merge_node 0 f t1 t2
 
-  let union t1 t2 =
-    merge (fun _ x y -> match (x, y) with _, None -> x | _, _ -> y) t1 t2
-
-  let union_f f t1 t2 =
+  let union f t1 t2 =
     merge
       (fun k x y ->
         match (x, y) with

--- a/lib/hamt.mli
+++ b/lib/hamt.mli
@@ -212,13 +212,8 @@ module type S = sig
       binding, and its corresponding value, are determined by the
       function [f]. *)
 
-  val union : 'a t -> 'a t -> 'a t
-  (** [union t1 t2] returns a table whose keys are all keys presents in
-      [t1] or in [t2]. If the key is present in both tables, the
-      corresponding value is the one bound in [t2]. *)
-
-  val union_f : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
-  (** [union_f f t1 t2] returns a table whose keys are all keys
+  val union : (key -> 'a -> 'a -> 'a) -> 'a t -> 'a t -> 'a t
+  (** [union f t1 t2] returns a table whose keys are all keys
       presents in [t1] or in [t2]. If a key [k] is present in only one
       table, the corresponding value is chosen in the result. If it is
       bound to [v1] in [t1] and [v2] in [t2], the value in the result


### PR DESCRIPTION
use union for union_f and remove the other function

I'd like to match the stdlib as much as possible to make it trivial to experiment with this library.