### PR TITLE
remove [Infix] operations

### DIFF
--- a/lib/hamt.ml
+++ b/lib/hamt.ml
@@ -199,11 +199,6 @@ module type S = sig
     val find : key -> 'a t -> 'a option
     val choose : 'a t -> (key * 'a) option
   end
-
-  module Infix : sig
-    val ( --> ) : 'a t -> key -> 'a
-    val ( <-- ) : 'a t -> key * 'a -> 'a t
-  end
 end
 
 module Make (Config : CONFIG) (Key : Hashtbl.HashedType) :
@@ -829,11 +824,6 @@ module Make (Config : CONFIG) (Key : Hashtbl.HashedType) :
     let modify k f hamt = try modify k f hamt with Not_found -> hamt
     let find k hamt = find_opt k hamt
     let choose hamt = try Some (choose hamt) with Not_found -> None
-  end
-
-  module Infix = struct
-    let ( --> ) hamt k = find k hamt
-    let ( <-- ) hamt (k, v) = add k v hamt
   end
 end
 

--- a/lib/hamt.mli
+++ b/lib/hamt.mli
@@ -290,17 +290,6 @@ module type S = sig
     val find : key -> 'a t -> 'a option
     val choose : 'a t -> (key * 'a) option
   end
-
-  (** Infix operations. *)
-  module Infix : sig
-    val ( --> ) : 'a t -> key -> 'a
-    (** [t --> k] returns the current binding of [k] in [t], or
-        raises [Not_found]. Strictly equivalent to [find_exn k t]. *)
-
-    val ( <-- ) : 'a t -> key * 'a -> 'a t
-    (** [t <-- (k, v)] adds to [t] a binding from [k] to [v] and
-        returns the result. Strictly equivalent to [add k v Hamt]. *)
-  end
 end
 
 (** Functor building an implementation of the Hamt structure,


### PR DESCRIPTION
They are not standard across OCaml libraries and the convenience offered
is very minor.
